### PR TITLE
consensus: align receipt RLP to geth (no L1 gas); fix bloom/log decoding and tests

### DIFF
--- a/crates/consensus/src/receipt.rs
+++ b/crates/consensus/src/receipt.rs
@@ -3,12 +3,13 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
+use alloy_primitives::{Address, B256, U256};
+use alloy_rlp::{Decodable, Encodable, Header};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ArbReceiptEnvelope {
     pub status: bool,
     pub cumulative_gas_used: u128,
-    pub l1_gas_used: Option<u128>,
     pub logs_bloom: [u8; 256],
     pub logs: Vec<ArbLog>,
 }
@@ -20,36 +21,258 @@ pub struct ArbLog {
     pub data: Vec<u8>,
 }
 
+impl Encodable for ArbLog {
+    fn length(&self) -> usize {
+        let mut tmp = Vec::new();
+
+        let addr = Address::from_slice(&self.address);
+        addr.encode(&mut tmp);
+
+        let mut topics_bytes = Vec::new();
+        for t in &self.topics {
+            let b = B256::from_slice(t);
+            b.encode(&mut topics_bytes);
+        }
+        Header { list: true, payload_length: topics_bytes.len() }.encode(&mut tmp);
+        tmp.extend_from_slice(&topics_bytes);
+
+        (&self.data[..]).encode(&mut tmp);
+
+        let header_len = alloy_rlp::length_of_length(tmp.len()) + 1;
+        header_len + tmp.len()
+    }
+
+    fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+        let mut tmp = Vec::new();
+
+        let addr = Address::from_slice(&self.address);
+        addr.encode(&mut tmp);
+
+        let mut topics_bytes = Vec::new();
+        for t in &self.topics {
+            let b = B256::from_slice(t);
+            b.encode(&mut topics_bytes);
+        }
+        Header { list: true, payload_length: topics_bytes.len() }.encode(&mut tmp);
+        tmp.extend_from_slice(&topics_bytes);
+
+        (&self.data[..]).encode(&mut tmp);
+
+        Header { list: true, payload_length: tmp.len() }.encode(out);
+        out.put_slice(&tmp);
+    }
+}
+
+impl Decodable for ArbLog {
+    fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
+        let header = Header::decode(buf)?;
+        let (payload, rest) = buf.split_at(header.payload_length);
+        let mut p = payload;
+
+        let addr: Address = Decodable::decode(&mut p)?;
+
+        let topics_header = Header::decode(&mut p)?;
+        if !topics_header.list {
+            return Err(alloy_rlp::Error::Custom("topics not a list"));
+        }
+        let (topics_payload, topics_rest) = p.split_at(topics_header.payload_length);
+        let mut tp = topics_payload;
+
+        let mut topics: Vec<[u8; 32]> = Vec::new();
+        while !tp.is_empty() {
+            let b: B256 = Decodable::decode(&mut tp)?;
+            let mut t = [0u8; 32];
+            t.copy_from_slice(b.as_slice());
+            topics.push(t);
+        }
+        p = topics_rest;
+
+        let data_hdr = Header::decode(&mut p)?;
+        if data_hdr.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        if p.len() < data_hdr.payload_length {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+        let (data_payload, rest_after_data) = p.split_at(data_hdr.payload_length);
+        let data: Vec<u8> = data_payload.to_vec();
+        p = rest_after_data;
+
+        if !p.is_empty() {
+            return Err(alloy_rlp::Error::Custom("log payload not fully consumed"));
+        }
+
+        let mut address = [0u8; 20];
+        address.copy_from_slice(addr.as_slice());
+
+        *buf = rest;
+        Ok(ArbLog { address, topics, data })
+    }
+}
+
+impl Encodable for ArbReceiptEnvelope {
+    fn length(&self) -> usize {
+        let mut tmp = Vec::new();
+
+        U256::from(if self.status { 1u8 } else { 0u8 }).encode(&mut tmp);
+        U256::from(self.cumulative_gas_used).encode(&mut tmp);
+        (&self.logs_bloom[..]).encode(&mut tmp);
+
+        let mut logs_bytes = Vec::new();
+        for log in &self.logs {
+            log.encode(&mut logs_bytes);
+        }
+        Header { list: true, payload_length: logs_bytes.len() }.encode(&mut tmp);
+        tmp.extend_from_slice(&logs_bytes);
+
+        let header_len = alloy_rlp::length_of_length(tmp.len()) + 1;
+        header_len + tmp.len()
+    }
+
+    fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+        let mut tmp = Vec::new();
+
+        U256::from(if self.status { 1u8 } else { 0u8 }).encode(&mut tmp);
+        U256::from(self.cumulative_gas_used).encode(&mut tmp);
+        (&self.logs_bloom[..]).encode(&mut tmp);
+
+        let mut logs_bytes = Vec::new();
+        for log in &self.logs {
+            log.encode(&mut logs_bytes);
+        }
+        Header { list: true, payload_length: logs_bytes.len() }.encode(&mut tmp);
+        tmp.extend_from_slice(&logs_bytes);
+
+        Header { list: true, payload_length: tmp.len() }.encode(out);
+        out.put_slice(&tmp);
+    }
+}
+
+impl Decodable for ArbReceiptEnvelope {
+    fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
+        let header = Header::decode(buf)?;
+        let (payload, rest) = buf.split_at(header.payload_length);
+        let mut p = payload;
+
+
+        let status_u: U256 = Decodable::decode(&mut p)?;
+        let status = !status_u.is_zero();
+
+
+        let cg_u256: U256 = Decodable::decode(&mut p)?;
+        let cumulative_gas_used = cg_u256.to::<u128>();
+
+
+        let bloom_header = Header::decode(&mut p)?;
+        if bloom_header.list {
+            return Err(alloy_rlp::Error::Custom("logs_bloom must be a string"));
+        }
+        if bloom_header.payload_length != 256 {
+            return Err(alloy_rlp::Error::Custom("logs_bloom must be 256 bytes"));
+        }
+        if p.len() < 256 {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+        let (bloom_payload, rest_after_bloom) = p.split_at(256);
+        let mut logs_bloom = [0u8; 256];
+        logs_bloom.copy_from_slice(bloom_payload);
+        p = rest_after_bloom;
+
+
+        let logs_header = Header::decode(&mut p)?;
+        if !logs_header.list {
+            return Err(alloy_rlp::Error::Custom("logs not a list"));
+        }
+        let (logs_payload, logs_rest) = p.split_at(logs_header.payload_length);
+        let mut lp = logs_payload;
+
+        let mut logs: Vec<ArbLog> = Vec::new();
+        while !lp.is_empty() {
+            let log: ArbLog = Decodable::decode(&mut lp)?;
+            logs.push(log);
+        }
+        if !logs_rest.is_empty() {
+            return Err(alloy_rlp::Error::Custom("logs overconsumed"));
+        }
+        p = logs_rest;
+
+        if !p.is_empty() {
+            return Err(alloy_rlp::Error::Custom("receipt payload not fully consumed"));
+        }
+
+        *buf = rest;
+        Ok(ArbReceiptEnvelope { status, cumulative_gas_used, logs_bloom, logs })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
-    #[test]
-    fn basic_receipt_envelope_fields() {
-        let r = ArbReceiptEnvelope {
-            status: true,
-            cumulative_gas_used: 12345,
-            l1_gas_used: None,
-            logs_bloom: [0u8; 256],
-            logs: Vec::new(),
-        };
-        assert!(r.status);
-        assert_eq!(r.cumulative_gas_used, 12345);
-        assert_eq!(r.l1_gas_used, None);
-        assert_eq!(r.logs.len(), 0);
+    fn sample_log() -> ArbLog {
+        ArbLog {
+            address: {
+                let a = Address::from_slice(&[0u8; 20]);
+                let mut out = [0u8; 20];
+                out.copy_from_slice(a.as_slice());
+                out
+            },
+            topics: vec![[0u8; 32], {
+                let mut t = [0u8; 32];
+                t[0] = 1;
+                t[31] = 2;
+                t
+            }],
+            data: vec![0xde, 0xad, 0xbe, 0xef],
+        }
     }
 
     #[test]
-    fn l1_gas_used_optional_field_works() {
+    fn receipt_roundtrip_no_logs() {
         let r = ArbReceiptEnvelope {
-            status: false,
-            cumulative_gas_used: 1,
-            l1_gas_used: Some(777),
+            status: true,
+            cumulative_gas_used: 12345,
             logs_bloom: [0u8; 256],
             logs: Vec::new(),
         };
-        assert!(!r.status);
-        assert_eq!(r.cumulative_gas_used, 1);
-        assert_eq!(r.l1_gas_used, Some(777));
+        let mut out = Vec::new();
+        r.encode(&mut out);
+        let mut s = out.as_slice();
+        let dec = <ArbReceiptEnvelope as Decodable>::decode(&mut s).unwrap();
+        assert!(s.is_empty());
+        assert_eq!(dec, r);
+    }
+
+    #[test]
+    fn receipt_roundtrip_with_logs() {
+        let r = ArbReceiptEnvelope {
+            status: false,
+            cumulative_gas_used: 1_000_000,
+            logs_bloom: [0x11u8; 256],
+            logs: vec![sample_log()],
+        };
+        let mut out = Vec::new();
+        r.encode(&mut out);
+        let mut s = out.as_slice();
+        let dec = <ArbReceiptEnvelope as Decodable>::decode(&mut s).unwrap();
+        assert!(s.is_empty());
+        assert_eq!(dec, r);
+    }
+
+    #[test]
+    fn receipt_length_header_matches_payload() {
+        let r = ArbReceiptEnvelope {
+            status: true,
+            cumulative_gas_used: 42,
+            logs_bloom: [0u8; 256],
+            logs: vec![sample_log(), sample_log()],
+        };
+        let mut out = Vec::new();
+        r.encode(&mut out);
+
+        let mut s = out.as_slice();
+        let h = Header::decode(&mut s).unwrap();
+        assert_eq!(h.payload_length, s.len());
     }
 }


### PR DESCRIPTION
# consensus: align receipt RLP to geth (no L1 gas); fix bloom/log decoding and tests

## Summary

This PR fixes the receipt RLP encoding in `arb-alloy` to match Nitro/go-ethereum's consensus format, resolving `InputTooShort` and `UnexpectedString` test failures that were blocking progress.

**Key changes:**
- **Removed `l1_gas_used` from consensus receipt RLP** - Nitro's consensus receipts use standard Ethereum format `[status, cumulative_gas_used, logs_bloom, logs]` without L1 gas
- **Fixed bloom filter decoding** - Switched from `Vec<u8>` Decodable to manual header parsing to avoid UnexpectedString errors
- **Fixed log data decoding** - Applied same manual header parsing approach to log data field
- **Updated tests** - All receipt roundtrip tests now pass, confirming proper encoding/decoding

This aligns `arb-alloy` with the reference implementation in `/home/ubuntu/repos/nitro/go-ethereum/core/types/receipt.go` where consensus receipts exclude L1 gas (it's only present in storage format).

## Review & Testing Checklist for Human

- [ ] **Verify RLP format matches Nitro exactly** - Compare encoded bytes against real Arbitrum receipts or Nitro test vectors
- [ ] **Test with real Arbitrum receipt data** - Ensure decoding works with actual mainnet/testnet receipt data
- [ ] **Confirm l1_gas_used removal doesn't break other components** - Check if any other parts of arb-alloy or reth expect l1_gas_used in consensus receipts
- [ ] **Review manual header parsing logic** - Validate the bloom and log data parsing for correctness and edge case handling

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    subgraph "arb-alloy/crates/consensus/src"
        receipt["receipt.rs<br/>[ArbReceiptEnvelope + ArbLog]"]:::major-edit
        tx["tx.rs<br/>[Transaction types]"]:::context
    end
    
    subgraph "Reference Implementation"
        nitro["nitro/go-ethereum/core/types/<br/>receipt.go"]:::context
    end
    
    subgraph "Test Suite"
        tests["receipt::tests<br/>[roundtrip + validation]"]:::major-edit
    end
    
    receipt --> tests
    nitro -->|"RLP format reference"| receipt
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#F5F5F5
```

### Notes

This change is critical for enabling proper reth-arbitrum integration. The receipt RLP format must be bit-for-bit compatible with Nitro for consensus compatibility.

**Session**: Requested by Til Jordan (@tiljrd)    
**Link to Devin run**: https://app.devin.ai/sessions/5af54e714c7549e8b94933b33ea90e52