### PR TITLE
arb-alloy: retryables helpers + tests; predeploy selector expansions

### DIFF
--- a/crates/consensus/src/tx.rs
+++ b/crates/consensus/src/tx.rs
@@ -598,6 +598,25 @@ mod tests {
             let back = ArbTxType::from_u8(b).unwrap();
             assert_eq!(t, back);
         }
+    #[test]
+    fn exact_type_bytes_match_nitro_spec() {
+        assert_eq!(ArbTxType::ArbitrumDepositTx.as_u8(), 0x64);
+        assert_eq!(ArbTxType::ArbitrumUnsignedTx.as_u8(), 0x65);
+        assert_eq!(ArbTxType::ArbitrumContractTx.as_u8(), 0x66);
+        assert_eq!(ArbTxType::ArbitrumRetryTx.as_u8(), 0x68);
+        assert_eq!(ArbTxType::ArbitrumSubmitRetryableTx.as_u8(), 0x69);
+        assert_eq!(ArbTxType::ArbitrumInternalTx.as_u8(), 0x6a);
+        assert_eq!(ArbTxType::ArbitrumLegacyTx.as_u8(), 0x78);
+
+        assert_eq!(ArbTxType::from_u8(0x64).unwrap(), ArbTxType::ArbitrumDepositTx);
+        assert_eq!(ArbTxType::from_u8(0x65).unwrap(), ArbTxType::ArbitrumUnsignedTx);
+        assert_eq!(ArbTxType::from_u8(0x66).unwrap(), ArbTxType::ArbitrumContractTx);
+        assert_eq!(ArbTxType::from_u8(0x68).unwrap(), ArbTxType::ArbitrumRetryTx);
+        assert_eq!(ArbTxType::from_u8(0x69).unwrap(), ArbTxType::ArbitrumSubmitRetryableTx);
+        assert_eq!(ArbTxType::from_u8(0x6a).unwrap(), ArbTxType::ArbitrumInternalTx);
+        assert_eq!(ArbTxType::from_u8(0x78).unwrap(), ArbTxType::ArbitrumLegacyTx);
+    }
+
     }
 
     #[test]

--- a/crates/consensus/src/tx.rs
+++ b/crates/consensus/src/tx.rs
@@ -848,3 +848,27 @@ mod tests {
         );
     }
 }
+    #[test]
+    fn decode_typed_rejects_unknown_type() {
+        let mut bad = vec![0xff, 0xc0]; // invalid type byte + minimal payload
+        assert!(matches!(
+            ArbTxEnvelope::decode_typed(&bad),
+            Err(TxTypeError::UnknownType(0xff))
+        ));
+        bad[0] = 0x00; // not an Arbitrum type in this module
+        assert!(matches!(
+            ArbTxEnvelope::decode_typed(&bad),
+            Err(TxTypeError::UnknownType(0x00))
+        ));
+    }
+
+    #[test]
+    fn legacy_passthrough_reports_full_length() {
+        let legacy_payload: Vec<u8> = alloy_rlp::encode(alloy_primitives::U256::from(7u64));
+        let mut bytes = Vec::with_capacity(1 + legacy_payload.len());
+        bytes.push(ArbTxType::ArbitrumLegacyTx.as_u8());
+        bytes.extend_from_slice(&legacy_payload);
+        let (env, used) = ArbTxEnvelope::decode_typed(&bytes).expect("decode");
+        assert!(matches!(env, ArbTxEnvelope::Legacy(_)));
+        assert_eq!(used, bytes.len(), "legacy decode should consume full input");
+    }

--- a/crates/predeploys/src/lib.rs
+++ b/crates/predeploys/src/lib.rs
@@ -179,6 +179,8 @@ mod tests {
             let sel = selector(sig);
             assert_eq!(sel.len(), 4);
         }
+    }
+
     #[test]
     fn owner_selectors_compile() {
         for sig in [
@@ -194,7 +196,5 @@ mod tests {
             let sel = selector(sig);
             assert_eq!(sel.len(), 4);
         }
-    }
-
     }
 }

--- a/crates/predeploys/src/lib.rs
+++ b/crates/predeploys/src/lib.rs
@@ -36,6 +36,10 @@ pub const SIG_GET_TX_ORIGIN: &str = "getTxOrigin()";
 pub const SIG_GET_BLOCK_NUMBER: &str = "getBlockNumber()";
 pub const SIG_GET_BLOCK_HASH: &str = "getBlockHash(uint64)";
 pub const SIG_GET_STORAGE_AT: &str = "getStorageAt(address,bytes32)";
+pub const SIG_ARB_CHAIN_ID: &str = "arbChainID()";
+pub const SIG_ARB_OS_VERSION: &str = "arbOSVersion()";
+pub const SIG_ARB_CHAIN_ID: &str = "arbChainID()";
+pub const SIG_ARB_OS_VERSION: &str = "arbOSVersion()";
 
 /* ArbAddressTable */
 pub const SIG_AT_ADDRESS_EXISTS: &str = "addressExists(address)";

--- a/crates/predeploys/src/lib.rs
+++ b/crates/predeploys/src/lib.rs
@@ -47,6 +47,17 @@ pub const SIG_OWNER_GET_NETWORK_FEE_ACCOUNT: &str = "getNetworkFeeAccount()";
 pub const SIG_OWNER_GET_INFRA_FEE_ACCOUNT: &str = "getInfraFeeAccount()";
 pub const SIG_OWNER_SET_NETWORK_FEE_ACCOUNT: &str = "setNetworkFeeAccount(address)";
 pub const SIG_OWNER_SET_INFRA_FEE_ACCOUNT: &str = "setInfraFeeAccount(address)";
+/* ArbRetryableTx */
+pub const SIG_RETRY_GET_LIFETIME: &str = "getLifetime()";
+pub const SIG_RETRY_GET_TIMEOUT: &str = "getTimeout(bytes32)";
+pub const SIG_RETRY_KEEPALIVE: &str = "keepalive(bytes32)";
+pub const SIG_RETRY_GET_BENEFICIARY: &str = "getBeneficiary(bytes32)";
+pub const SIG_RETRY_REDEEM: &str = "redeem(bytes32)";
+pub const SIG_RETRY_CANCEL: &str = "cancel(bytes32)";
+pub const SIG_RETRY_GET_CURRENT_REDEEMER: &str = "getCurrentRedeemer()";
+/* Non-callable but present for explorers */
+pub const SIG_RETRY_SUBMIT_RETRYABLE: &str = "submitRetryable(bytes32,uint256,uint256,uint256,uint256,uint64,uint256,address,address,address,bytes)";
+
 
 
 /* ArbAddressTable */

--- a/crates/predeploys/src/lib.rs
+++ b/crates/predeploys/src/lib.rs
@@ -38,6 +38,16 @@ pub const SIG_GET_BLOCK_HASH: &str = "getBlockHash(uint64)";
 pub const SIG_GET_STORAGE_AT: &str = "getStorageAt(address,bytes32)";
 pub const SIG_ARB_CHAIN_ID: &str = "arbChainID()";
 pub const SIG_ARB_OS_VERSION: &str = "arbOSVersion()";
+/* ArbOwner */
+pub const SIG_OWNER_ADD_CHAIN_OWNER: &str = "addChainOwner(address)";
+pub const SIG_OWNER_REMOVE_CHAIN_OWNER: &str = "removeChainOwner(address)";
+pub const SIG_OWNER_IS_CHAIN_OWNER: &str = "isChainOwner(address)";
+pub const SIG_OWNER_GET_ALL_CHAIN_OWNERS: &str = "getAllChainOwners()";
+pub const SIG_OWNER_GET_NETWORK_FEE_ACCOUNT: &str = "getNetworkFeeAccount()";
+pub const SIG_OWNER_GET_INFRA_FEE_ACCOUNT: &str = "getInfraFeeAccount()";
+pub const SIG_OWNER_SET_NETWORK_FEE_ACCOUNT: &str = "setNetworkFeeAccount(address)";
+pub const SIG_OWNER_SET_INFRA_FEE_ACCOUNT: &str = "setInfraFeeAccount(address)";
+
 
 /* ArbAddressTable */
 pub const SIG_AT_ADDRESS_EXISTS: &str = "addressExists(address)";
@@ -169,5 +179,22 @@ mod tests {
             let sel = selector(sig);
             assert_eq!(sel.len(), 4);
         }
+    #[test]
+    fn owner_selectors_compile() {
+        for sig in [
+            SIG_OWNER_ADD_CHAIN_OWNER,
+            SIG_OWNER_REMOVE_CHAIN_OWNER,
+            SIG_OWNER_IS_CHAIN_OWNER,
+            SIG_OWNER_GET_ALL_CHAIN_OWNERS,
+            SIG_OWNER_GET_NETWORK_FEE_ACCOUNT,
+            SIG_OWNER_GET_INFRA_FEE_ACCOUNT,
+            SIG_OWNER_SET_NETWORK_FEE_ACCOUNT,
+            SIG_OWNER_SET_INFRA_FEE_ACCOUNT,
+        ] {
+            let sel = selector(sig);
+            assert_eq!(sel.len(), 4);
+        }
+    }
+
     }
 }

--- a/crates/predeploys/src/lib.rs
+++ b/crates/predeploys/src/lib.rs
@@ -38,8 +38,6 @@ pub const SIG_GET_BLOCK_HASH: &str = "getBlockHash(uint64)";
 pub const SIG_GET_STORAGE_AT: &str = "getStorageAt(address,bytes32)";
 pub const SIG_ARB_CHAIN_ID: &str = "arbChainID()";
 pub const SIG_ARB_OS_VERSION: &str = "arbOSVersion()";
-pub const SIG_ARB_CHAIN_ID: &str = "arbChainID()";
-pub const SIG_ARB_OS_VERSION: &str = "arbOSVersion()";
 
 /* ArbAddressTable */
 pub const SIG_AT_ADDRESS_EXISTS: &str = "addressExists(address)";

--- a/crates/util/src/l1_pricing.rs
+++ b/crates/util/src/l1_pricing.rs
@@ -84,5 +84,19 @@ mod tests {
     fn poster_data_cost_multiplies_base_fee_by_data_gas() {
         let state = L1PricingState { l1_base_fee_wei: 1_000 };
         assert_eq!(state.poster_data_cost(123456789), 123_456_789_000);
+    #[test]
+    fn poster_data_cost_is_zero_when_base_fee_zero() {
+        let state = L1PricingState { l1_base_fee_wei: 0 };
+        assert_eq!(state.poster_data_cost_from_units(123456), 0);
+        assert_eq!(state.poster_data_cost(987654321), 0);
+    }
+
+    #[test]
+    fn apply_estimation_padding_is_monotonic() {
+        let a = 10_000u128;
+        let b = 50_000u128;
+        assert!(L1PricingState::apply_estimation_padding(a) < L1PricingState::apply_estimation_padding(b));
+    }
+
     }
 }

--- a/crates/util/src/l1_pricing.rs
+++ b/crates/util/src/l1_pricing.rs
@@ -99,4 +99,43 @@ mod tests {
         let b = 50_000u128;
         assert!(L1PricingState::apply_estimation_padding(a) < L1PricingState::apply_estimation_padding(b));
     }
+    #[test]
+    fn poster_units_monotonic_in_len() {
+        let mut prev = 0u128;
+        for len in 0u64..=1024 {
+            let units = L1PricingState::poster_units_from_brotli_len(len);
+            assert!(units >= prev);
+            prev = units;
+        }
+    }
+
+    #[test]
+    fn apply_padding_increases_units() {
+        let samples: [u128; 6] = [0, 1, 15, 16, 256, 4096];
+        for units in samples {
+            let padded = L1PricingState::apply_estimation_padding(units);
+            assert!(padded >= units);
+            let min_expected = units + ESTIMATION_PADDING_UNITS as u128;
+            assert!(padded >= min_expected);
+            let max_expected = (min_expected * (ONE_IN_BIPS as u128 + ESTIMATION_PADDING_BASIS_POINTS as u128)) / ONE_IN_BIPS as u128;
+            assert!(padded <= max_expected + 1);
+        }
+    }
+
+    #[test]
+    fn data_cost_linear_in_basefee() {
+        let state_zero = L1PricingState { l1_base_fee_wei: 0 };
+        assert_eq!(state_zero.poster_data_cost_from_units(0), 0);
+        assert_eq!(state_zero.poster_data_cost_from_units(12345), 0);
+
+        let units_list: [u128; 4] = [0, 1, 10, 1000];
+        let fees: [u128; 4] = [0, 1, 10, 123_456_789];
+        for units in units_list {
+            for fee in fees {
+                let st = L1PricingState { l1_base_fee_wei: fee };
+                assert_eq!(st.poster_data_cost_from_units(units), units.saturating_mul(fee));
+            }
+        }
+    }
+
 }

--- a/crates/util/src/l1_pricing.rs
+++ b/crates/util/src/l1_pricing.rs
@@ -84,6 +84,8 @@ mod tests {
     fn poster_data_cost_multiplies_base_fee_by_data_gas() {
         let state = L1PricingState { l1_base_fee_wei: 1_000 };
         assert_eq!(state.poster_data_cost(123456789), 123_456_789_000);
+    }
+
     #[test]
     fn poster_data_cost_is_zero_when_base_fee_zero() {
         let state = L1PricingState { l1_base_fee_wei: 0 };
@@ -96,7 +98,5 @@ mod tests {
         let a = 10_000u128;
         let b = 50_000u128;
         assert!(L1PricingState::apply_estimation_padding(a) < L1PricingState::apply_estimation_padding(b));
-    }
-
     }
 }

--- a/crates/util/src/retryables.rs
+++ b/crates/util/src/retryables.rs
@@ -25,6 +25,10 @@ pub fn escrow_address_from_ticket(ticket_id: [u8; 32]) -> [u8; 20] {
     out
 }
 
+pub fn retryable_timeout_from(now_secs: u64) -> u64 {
+    now_secs.saturating_add(RETRYABLE_LIFETIME_SECONDS)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -79,5 +83,14 @@ mod tests {
         let fee1 = retryable_submission_fee(len, f1);
         let fee2 = retryable_submission_fee(len, f2);
         assert_eq!(fee2, fee1 * (f2 / f1));
+    }
+
+    #[test]
+    fn retryable_timeout_adds_lifetime_and_saturates() {
+        let now = 1_000u64;
+        assert_eq!(retryable_timeout_from(now), now + RETRYABLE_LIFETIME_SECONDS);
+        let near_max = u64::MAX - 10;
+        let res = retryable_timeout_from(near_max);
+        assert_eq!(res, u64::MAX);
     }
 }

--- a/crates/util/src/retryables.rs
+++ b/crates/util/src/retryables.rs
@@ -1,3 +1,4 @@
+
 #![allow(dead_code)]
 
 extern crate alloc;
@@ -34,6 +35,7 @@ mod tests {
         assert_eq!(RETRYABLE_LIFETIME_SECONDS, 7 * 24 * 60 * 60);
         assert_eq!(RETRYABLE_REAP_PRICE_UNITS, 58_000);
     }
+
     #[test]
     fn submission_fee_matches_nitro_formula() {
         let calldata_len = 100usize;
@@ -67,6 +69,8 @@ mod tests {
         let mut expected = [0u8; 20];
         expected.copy_from_slice(&hash.as_slice()[12..32]);
         assert_eq!(escrow_address_from_ticket(ticket), expected);
+    }
+
     #[test]
     fn submission_fee_scales_linearly_with_base_fee() {
         let len = 256usize;
@@ -75,7 +79,5 @@ mod tests {
         let fee1 = retryable_submission_fee(len, f1);
         let fee2 = retryable_submission_fee(len, f2);
         assert_eq!(fee2, fee1 * (f2 / f1));
-    }
-
     }
 }

--- a/crates/util/src/retryables.rs
+++ b/crates/util/src/retryables.rs
@@ -67,5 +67,15 @@ mod tests {
         let mut expected = [0u8; 20];
         expected.copy_from_slice(&hash.as_slice()[12..32]);
         assert_eq!(escrow_address_from_ticket(ticket), expected);
+    #[test]
+    fn submission_fee_scales_linearly_with_base_fee() {
+        let len = 256usize;
+        let f1 = 1_000u128;
+        let f2 = 5_000u128;
+        let fee1 = retryable_submission_fee(len, f1);
+        let fee2 = retryable_submission_fee(len, f2);
+        assert_eq!(fee2, fee1 * (f2 / f1));
+    }
+
     }
 }


### PR DESCRIPTION
# arb-reth: Arbitrum EVM integration scaffolding with predeploys, receipts, and CLI

## Summary

This PR implements the foundational scaffolding for arb-reth as an alternative execution client for Arbitrum. Key additions include:

- **C-KZG version conflict resolution**: Added workspace patch for `revm-precompile = "=25.0.0"` to converge on c-kzg 2.x and unblock builds
- **Predeploy handler implementations**: ArbSys, ArbRetryableTx, NodeInterface, ArbOwner, ArbAddressTable, and ArbGasInfo with ABI-correct signatures and basic functionality
- **Arbitrum receipt building**: Receipt variant mapping for all Arbitrum transaction types with consensus RLP encoding (excluding L1 gas fields)
- **Transaction envelope decoding**: Integration with arb-alloy consensus types to decode all Arbitrum 2718 envelopes
- **Dedicated arb-reth binary**: CLI with chainspec support and dev chain configuration
- **Comprehensive test coverage**: Unit tests for predeploy dispatching, ABI shapes, and transaction type mapping

The implementation follows the modular pattern established by reth-optimism, maintaining upstream compatibility while adding Arbitrum-specific execution logic.

## Review & Testing Checklist for Human

- [ ] **Verify c-kzg patch resolves build conflicts**: Run `cargo build -p reth-arbitrum-bin` to confirm the revm-precompile patch eliminates the native library version conflict
- [ ] **Test predeploy ABI compatibility**: Compare ABI outputs against Nitro's precompiles to ensure exact byte-for-byte parity, especially for NodeInterface gas estimation functions
- [ ] **Validate transaction envelope decoding**: Test decoding of all Arbitrum transaction types (0x64-0x6A, 0x78) against known Nitro-generated vectors
- [ ] **Run test suites**: Execute `cargo test -p reth-arbitrum-*` to verify all unit tests pass, particularly predeploy handler tests
- [ ] **Check receipt consensus encoding**: Ensure receipt RLP excludes L1 gas fields and matches arb-alloy consensus format

**Recommended test plan**: After verifying builds succeed, test predeploy calls via simple JSON-RPC to ensure ABI correctness, then proceed with Docker image building and Kurtosis integration testing.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    CargoToml["reth/Cargo.toml<br/>[patch.crates-io]"]:::major-edit
    ChainspecCargo["crates/arbitrum/chainspec/Cargo.toml<br/>revm = 27.0.3"]:::major-edit
    
    EvmLib["crates/arbitrum/evm/src/lib.rs<br/>ArbEvmConfig + envelope decoding"]:::major-edit
    Predeploys["crates/arbitrum/evm/src/predeploys.rs<br/>Handler implementations"]:::major-edit
    Receipts["crates/arbitrum/evm/src/receipts.rs<br/>Receipt building"]:::minor-edit
    Execute["crates/arbitrum/evm/src/execute.rs<br/>ArbOS hooks (scaffolded)"]:::context
    
    BinMain["crates/arbitrum/bin/src/main.rs<br/>arb-reth CLI"]:::major-edit
    
    ArbAlloy["arb-alloy consensus types"]:::context
    RethPrimitives["reth-arbitrum-primitives"]:::context
    
    CargoToml --> ChainspecCargo
    EvmLib --> ArbAlloy
    EvmLib --> RethPrimitives
    Predeploys --> ArbAlloy
    BinMain --> EvmLib
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Critical dependency fix**: The c-kzg version conflict was the primary blocker preventing any builds. The workspace patch should force convergence on c-kzg 2.x across the entire dependency graph.
- **Predeploy semantic gaps**: While ABI signatures are correct, many handlers return placeholder values rather than accessing real Arbitrum state. Full semantic parity with Nitro requires additional state management implementation.
- **Missing ArbOS hooks**: The Start/GasCharging/End hooks in execute.rs are scaffolded but not fully implemented. These are critical for proper L1 gas accounting and fee handling.
- **Next steps**: After verifying builds work, focus on implementing retryables lifecycle, completing ArbOS hooks, and building the Docker image for Kurtosis testing.

**Session info**: Requested by Til Jordan (@tiljrd)  
**Devin run**: https://app.devin.ai/sessions/9399cf2836da4302b3bea9445798753f