### PR TITLE
arb-alloy: golden vectors + property tests for Arb envelopes/receipts (Nitro parity scaffolding)

### DIFF
--- a/crates/consensus/src/receipt.rs
+++ b/crates/consensus/src/receipt.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 #![allow(dead_code)]
 
 extern crate alloc;
@@ -329,6 +331,22 @@ mod golden {
         assert!(s.is_empty());
         let mut out = alloc::vec::Vec::new();
         dec.encode(&mut out);
+        assert_eq!(out, golden);
+    }
+}
+#[cfg(test)]
+mod golden {
+    use super::*;
+    #[test]
+    #[ignore]
+    fn golden_receipt_envelope_matches_nitro_rlp() {
+        let golden: alloc::vec::Vec<u8> = alloc::vec::Vec::new();
+        let mut s = golden.as_slice();
+        let (env, used) = ArbReceiptEnvelope::decode_typed(&mut s).expect("decode");
+        assert!(s.is_empty());
+        assert_eq!(used, golden.len());
+        let mut out = alloc::vec::Vec::new();
+        env.encode_typed(&mut out);
         assert_eq!(out, golden);
     }
 }

--- a/crates/consensus/src/tx.rs
+++ b/crates/consensus/src/tx.rs
@@ -1003,4 +1003,78 @@ mod golden {
         let out = env.encode_typed();
         assert_eq!(out, golden);
     }
+#[cfg(test)]
+mod golden_more {
+    use super::*;
+    #[test]
+    #[ignore]
+    fn golden_contract_matches_nitro_rlp() {
+        let golden: Vec<u8> = Vec::new();
+        let mut s = golden.as_slice();
+        let (env, used) = ArbTxEnvelope::decode_typed(&mut s).expect("decode");
+        assert!(s.is_empty());
+        assert_eq!(used, golden.len());
+        assert!(matches!(env, ArbTxEnvelope::Contract(_)));
+        let mut out = Vec::new();
+        env.encode_typed(&mut out);
+        assert_eq!(out, golden);
+    }
+
+    #[test]
+    #[ignore]
+    fn golden_retry_matches_nitro_rlp() {
+        let golden: Vec<u8> = Vec::new();
+        let mut s = golden.as_slice();
+        let (env, used) = ArbTxEnvelope::decode_typed(&mut s).expect("decode");
+        assert!(s.is_empty());
+        assert_eq!(used, golden.len());
+        assert!(matches!(env, ArbTxEnvelope::Retry(_)));
+        let mut out = Vec::new();
+        env.encode_typed(&mut out);
+        assert_eq!(out, golden);
+    }
+
+    #[test]
+    #[ignore]
+    fn golden_submit_retryable_matches_nitro_rlp() {
+        let golden: Vec<u8> = Vec::new();
+        let mut s = golden.as_slice();
+        let (env, used) = ArbTxEnvelope::decode_typed(&mut s).expect("decode");
+        assert!(s.is_empty());
+        assert_eq!(used, golden.len());
+        assert!(matches!(env, ArbTxEnvelope::SubmitRetryable(_)));
+        let mut out = Vec::new();
+        env.encode_typed(&mut out);
+        assert_eq!(out, golden);
+    }
+
+    #[test]
+    #[ignore]
+    fn golden_internal_matches_nitro_rlp() {
+        let golden: Vec<u8> = Vec::new();
+        let mut s = golden.as_slice();
+        let (env, used) = ArbTxEnvelope::decode_typed(&mut s).expect("decode");
+        assert!(s.is_empty());
+        assert_eq!(used, golden.len());
+        assert!(matches!(env, ArbTxEnvelope::Internal(_)));
+        let mut out = Vec::new();
+        env.encode_typed(&mut out);
+        assert_eq!(out, golden);
+    }
+
+    #[test]
+    #[ignore]
+    fn golden_deposit_matches_nitro_rlp() {
+        let golden: Vec<u8> = Vec::new();
+        let mut s = golden.as_slice();
+        let (env, used) = ArbTxEnvelope::decode_typed(&mut s).expect("decode");
+        assert!(s.is_empty());
+        assert_eq!(used, golden.len());
+        assert!(matches!(env, ArbTxEnvelope::Deposit(_)));
+        let mut out = Vec::new();
+        env.encode_typed(&mut out);
+        assert_eq!(out, golden);
+    }
+}
+
 }

--- a/crates/consensus/src/tx.rs
+++ b/crates/consensus/src/tx.rs
@@ -921,6 +921,73 @@ mod proptests {
             assert_eq!(used, enc.len());
             assert_eq!(dec, env);
         }
+
+        #[test]
+        fn typed_contract_roundtrip(
+            chain_id in arb_u256(),
+            request_id in arb_b256(),
+            from in arb_address(),
+            gas_fee_cap in arb_u256(),
+            gas in any::<u64>(),
+            to in opt_address(),
+            value in arb_u256(),
+            data in small_bytes(),
+        ) {
+            let env = ArbTxEnvelope::Contract(ArbContractTx { chain_id, request_id, from, gas_fee_cap, gas, to, value, data });
+            let enc = env.encode_typed();
+            let (dec, used) = ArbTxEnvelope::decode_typed(&enc).expect("decode");
+            assert_eq!(used, enc.len());
+            assert_eq!(dec, env);
+        }
+
+        #[test]
+        fn typed_retry_roundtrip(
+            chain_id in arb_u256(),
+            nonce in any::<u64>(),
+            from in arb_address(),
+            gas_fee_cap in arb_u256(),
+            gas in any::<u64>(),
+            to in opt_address(),
+            value in arb_u256(),
+            data in small_bytes(),
+            ticket_id in arb_b256(),
+            refund_to in arb_address(),
+            max_refund in arb_u256(),
+            submission_fee_refund in arb_u256(),
+        ) {
+            let env = ArbTxEnvelope::Retry(ArbRetryTx {
+                chain_id, nonce, from, gas_fee_cap, gas, to, value, data, ticket_id, refund_to, max_refund, submission_fee_refund
+            });
+            let enc = env.encode_typed();
+            let (dec, used) = ArbTxEnvelope::decode_typed(&enc).expect("decode");
+            assert_eq!(used, enc.len());
+            assert_eq!(dec, env);
+        }
+
+        #[test]
+        fn typed_submit_retryable_roundtrip(
+            chain_id in arb_u256(),
+            request_id in arb_b256(),
+            from in arb_address(),
+            l1_base_fee in arb_u256(),
+            deposit_value in arb_u256(),
+            gas_fee_cap in arb_u256(),
+            gas in any::<u64>(),
+            retry_to in opt_address(),
+            retry_value in arb_u256(),
+            beneficiary in arb_address(),
+            max_submission_fee in arb_u256(),
+            fee_refund_addr in arb_address(),
+            retry_data in small_bytes(),
+        ) {
+            let env = ArbTxEnvelope::SubmitRetryable(ArbSubmitRetryableTx {
+                chain_id, request_id, from, l1_base_fee, deposit_value, gas_fee_cap, gas, retry_to, retry_value, beneficiary, max_submission_fee, fee_refund_addr, retry_data
+            });
+            let enc = env.encode_typed();
+            let (dec, used) = ArbTxEnvelope::decode_typed(&enc).expect("decode");
+            assert_eq!(used, enc.len());
+            assert_eq!(dec, env);
+        }
     }
 }
 


### PR DESCRIPTION
# arb-reth: Arbitrum integration scaffolding (Nitro parity) — hooks, predeploys, primitives, Docker, tests

## Summary

This PR implements the foundational scaffolding for reth as an alternative execution client to nitro-geth for Arbitrum networks. The implementation focuses on maintaining exact consensus parity with Nitro while extending reth through dedicated crates rather than forking the base implementation.

**Key Components Added:**
- **Arbitrum transaction primitives** with 2718 envelope support and signer recovery
- **ArbOS execution hooks** for start/gas charging/end transaction lifecycle with L1 pricing
- **Predeploy handlers** for ArbSys, ArbRetryableTx, ArbOwner, ArbGasInfo, ArbAddressTable, NodeInterface
- **Retryables lifecycle management** with escrow accounting and ticket handling
- **Receipt mapping parity** ensuring consensus receipts exclude L1 fee fields
- **STF WASM determinism** with canonical input recording
- **Docker build configuration** for arb-reth binary with updated Rust toolchain
- **Kurtosis package scaffolding** to wire arb-reth with Nitro components (arbnode, inbox-reader, batch-poster)

## Review & Testing Checklist for Human

- [ ] **Build arb-reth Docker image** from `crates/arbitrum/bin/Dockerfile` and verify it compiles successfully with the new Rust 1.81/nightly toolchain and additional system dependencies
- [ ] **Validate consensus parity** by comparing ArbOS hook behavior, predeploy semantics, and transaction/receipt encodings against actual Nitro reference implementations
- [ ] **Test transaction envelope handling** across all Arbitrum transaction types (Deposit, Unsigned, Contract, Retry, SubmitRetryable, Internal, Legacy) to ensure correct decoding and signer recovery
- [ ] **Verify predeploy ABI compliance** especially for fee handling in ArbOwner/ArbGasInfo and retryable lifecycle in ArbRetryableTx - these must match Nitro's Solidity interfaces exactly
- [ ] **Run end-to-end Kurtosis deployment** with `kurtosis run --enclave test . --args-file ./args/minimal.yaml` to verify arb-reth produces L2 blocks and Nitro components submit to L1

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph "reth Integration"
        A["crates/arbitrum/primitives/src/lib.rs<br/>ArbTransactionSigned + traits"]:::major-edit
        B["crates/arbitrum/evm/src/execute.rs<br/>ArbOS hooks (start/gas/end)"]:::major-edit
        C["crates/arbitrum/evm/src/predeploys.rs<br/>ArbSys, ArbOwner, etc handlers"]:::major-edit
        D["crates/arbitrum/evm/src/retryables.rs<br/>Lifecycle + escrow accounting"]:::major-edit
        E["crates/arbitrum/evm/src/receipts.rs<br/>Receipt mapping (no L1 fees)"]:::minor-edit
        F["crates/arbitrum/bin/Dockerfile<br/>Build config + toolchain"]:::major-edit
    end
    
    subgraph "arb-alloy Integration"
        G["crates/consensus/src/tx.rs<br/>Golden vectors + proptests"]:::minor-edit
        H["crates/consensus/src/receipt.rs<br/>Receipt test scaffolding"]:::minor-edit
    end
    
    subgraph "Kurtosis Package"
        I["main.star<br/>Service wiring logic"]:::major-edit
        J["args/minimal.yaml<br/>Config parameters"]:::minor-edit
    end
    
    subgraph "Workspace Config"
        K["Cargo.toml<br/>revm-precompile pin"]:::minor-edit
    end

    A --> B
    B --> C
    C --> D
    G --> A
    H --> E
    I --> F
    K --> F

    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

**Critical Implementation Gaps Remaining:**
- Golden vectors in arb-alloy need real Nitro reference data (currently scaffolded)
- Several predeploy methods still return placeholders rather than full Nitro-compatible implementations
- ArbOS hooks integration with block executor pipeline needs final wiring
- Kurtosis service flags need completion based on nitro-testnode patterns

**Consensus Risk Areas:**
- Transaction type mappings and TxKind conversions must match Nitro exactly
- Predeploy ABI encodings and selector dispatch must be bit-for-bit compatible
- Receipt RLP encoding must exclude L1 fee fields for consensus compatibility

Requested by Til Jordan (@tiljrd)  
Link to Devin run: https://app.devin.ai/sessions/3a1f6008621d48a4bd1f50124eac20db